### PR TITLE
Create base structure for all tests components

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from 'cypress'
 
 export default defineConfig({
   e2e: {
-    baseUrl: 'http://localhost:1234'
+    baseUrl: 'https://www.saucedemo.com/'
   }
 })

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -3,5 +3,6 @@ import { defineConfig } from 'cypress'
 export default defineConfig({
   e2e: {
     baseUrl: 'https://www.saucedemo.com/'
-  }
+  },
+  "chromeWebSecurity": false
 })

--- a/cypress/datasets/loginPageCopy.json
+++ b/cypress/datasets/loginPageCopy.json
@@ -1,9 +1,8 @@
 {
     "errorMsg": {
-        "emptyLogin": "standard_user",
-        "emptyPassword": "secret_sauce",
-        "emptyLoginAndPassword": "Epic sadface: Username is required",
-        "lockedUser": "secret_sauce",
-        "wrongUser": ""
+        "emptyLogin": "Epic sadface: Username is required",
+        "emptyPassword": "Epic sadface: Password is required",
+        "lockedUser": "Epic sadface: Sorry, this user has been locked out.",
+        "wrongUser": "Epic sadface: Username and password do not match any user in this service"
     }
 }

--- a/cypress/datasets/loginPageCopy.json
+++ b/cypress/datasets/loginPageCopy.json
@@ -1,0 +1,9 @@
+{
+    "errorMsg": {
+        "emptyLogin": "standard_user",
+        "emptyPassword": "secret_sauce",
+        "emptyLoginAndPassword": "Epic sadface: Username is required",
+        "lockedUser": "secret_sauce",
+        "wrongUser": ""
+    }
+}

--- a/cypress/datasets/users.json
+++ b/cypress/datasets/users.json
@@ -1,0 +1,18 @@
+{
+    "standardUser": {
+        "login": "standard_user",
+        "password": "secret_sauce"
+    },
+    "lockedOutUser": {
+        "login": "locked_out_user",
+        "password": "secret_sauce"
+    },
+    "problemUser": {
+        "login": "problem_user",
+        "password": "secret_sauce"
+    },
+    "performanceGlitchUser": {
+        "login": "performance_glitch_user",
+        "password": "secret_sauce"
+    }
+}

--- a/cypress/e2e/LoginPage.cy.ts
+++ b/cypress/e2e/LoginPage.cy.ts
@@ -1,0 +1,30 @@
+import loginPage from '../utils/loginPage'
+import * as users from '../datasets/users.json';
+import * as loginPageCopy from '../datasets/loginPageCopy.json';
+
+describe('LoginPage', () => {
+
+  beforeEach(() => {
+    cy.visit('/');
+  })
+
+  it('should login successfuly correct user', () => {
+    
+    const LoginPage = new loginPage();
+
+    LoginPage.shouldDisplayLoginWrapper();
+    LoginPage.loginUser(users.standardUser);
+    LoginPage.shouldLoginSuccessfuly();
+  })
+
+  it('should display error message for empty login and password inputs', () => {
+    
+    const LoginPage = new loginPage();
+
+    LoginPage.shouldInputsBeEmpty();
+    LoginPage.clickOnLoginButton();
+    LoginPage.shouldDisplayLoginErrorMsg(loginPageCopy.errorMsg.emptyLoginAndPassword);
+    
+  })
+
+})

--- a/cypress/e2e/LoginPage.cy.ts
+++ b/cypress/e2e/LoginPage.cy.ts
@@ -23,7 +23,7 @@ describe('LoginPage', () => {
 
     LoginPage.shouldInputsBeEmpty();
     LoginPage.clickOnLoginButton();
-    LoginPage.shouldDisplayLoginErrorMsg(loginPageCopy.errorMsg.emptyLoginAndPassword);
+    LoginPage.shouldDisplayLoginErrorMsg(loginPageCopy.errorMsg.emptyLogin);
     
   })
 

--- a/cypress/e2e/spec.cy.ts
+++ b/cypress/e2e/spec.cy.ts
@@ -1,5 +1,0 @@
-describe('empty spec', () => {
-  it('passes', () => {
-    cy.visit('https://example.cypress.io')
-  })
-})

--- a/cypress/interfaces/users.ts
+++ b/cypress/interfaces/users.ts
@@ -1,0 +1,6 @@
+interface User {
+    login: string;
+    password: string;
+}
+
+export default User

--- a/cypress/locators/loginPageLocators.ts
+++ b/cypress/locators/loginPageLocators.ts
@@ -1,0 +1,25 @@
+class loginPage {
+
+    loginWrapper() {
+        return cy.get('.login_wrapper')
+    }
+
+    usernameInput() {
+        return cy.get('[data-test="username"]')
+    }
+
+    passwordInput() {
+        return cy.get('[data-test="password"]')
+    }
+
+    loginBtn() {
+        return cy.get('[data-test="login-button"]')
+    }
+
+    errorMsg() {
+        return cy.get('[data-test="error"]')
+    }
+
+}
+
+export default loginPage

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -5,4 +5,4 @@
       "types": ["cypress", "node"]
     },
     "include": ["**/*.ts"]
-  }
+}

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -2,7 +2,8 @@
     "compilerOptions": {
       "target": "es5",
       "lib": ["es5", "dom"],
-      "types": ["cypress", "node"]
+      "types": ["cypress", "node"],
+      "resolveJsonModule": true
     },
     "include": ["**/*.ts"]
-}
+ }

--- a/cypress/utils/loginPage.ts
+++ b/cypress/utils/loginPage.ts
@@ -1,0 +1,53 @@
+import loginPageLocators from "../locators/loginPageLocators";
+import User from "../interfaces/users";
+
+const LoginPage = new loginPageLocators();
+
+class loginPage {
+
+    clickOnLoginButton = () => {
+
+        LoginPage.loginBtn().click();
+
+    }
+
+    loginUser = (user: User) => {
+
+        LoginPage.usernameInput().type(user.login);
+        LoginPage.passwordInput().type(user.password);
+
+        this.clickOnLoginButton();
+
+    }
+
+    shouldDisplayLoginErrorMsg = (message: string) => {
+
+        cy.url().should('eq', Cypress.config().baseUrl);
+        LoginPage.loginWrapper().should('be.visible');
+        LoginPage.errorMsg().should('contain', message);
+
+    }
+
+    shouldLoginSuccessfuly = () => {
+
+        cy.url().should('not.eq', Cypress.config().baseUrl);
+        LoginPage.loginWrapper().should('not.exist');
+
+    }
+
+    shouldDisplayLoginWrapper = () => {
+
+        LoginPage.loginWrapper().should('be.visible');
+
+    }
+
+    shouldInputsBeEmpty = () => {
+
+        LoginPage.usernameInput().should('be.empty');
+        LoginPage.passwordInput().should('be.empty');
+
+    }
+
+}
+
+export default loginPage

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "compilerOptions": {
+      "baseUrl": "./",
+      "target": "es5",
+      "lib": ["es5", "dom"],
+      "types": ["cypress", "node"]  
+    },
+    "include": ["**/*.ts"],
+    "exclude": ["node_modules", "**/*.spec.ts"]
+}


### PR DESCRIPTION
Created base structure with folders and example files for PageObject pattern for Cypress framework.

- `datasets` folder contains json files with test datas and check/get thing by copy
- `interfaces` folder contains typescript interfaces for more complicated datasets
- `locators` folder contains functions which return gets on specific page elements
- `utils` folder contains functions which perform actions in Cypress eq. click on element, check visibility

Additionally added global tsconfig file to prevent `Couldn't find tsconfig.json. tsconfig-paths will be skipped` message showing when you run Cypress and some required config tweaks.